### PR TITLE
Not sure when this attribute changed on the Rally side, but .value throws an exception

### DIFF
--- a/pyral/restapi.py
+++ b/pyral/restapi.py
@@ -1247,7 +1247,7 @@ class Rally(object):
         if not matching_attrs:
             return None
         attribute = matching_attrs[0]
-        return [av.value for av in attribute.AllowedValues]
+        return [av.StringValue for av in attribute.AllowedValues]
 
 
     def addAttachment(self, artifact, filename, mime_type='text/plain'):


### PR DESCRIPTION
Switched over to .StringValue and it all seems to work again.  Let me know if you have any questions.  My testing was specifically around the "Package" attribute of "Defect" artifacts.
