### PR TITLE
Including capability to search issues in recycle bin and closed projects.

### DIFF
--- a/pyral/restapi.py
+++ b/pyral/restapi.py
@@ -1302,7 +1302,14 @@ class Rally(object):
         #resource_url = "%s&pagesize=%s" % (left, right)
 
         url, query_string = resource_url.split('?', 1)
-        resource_url = "%s?keywords=%s&%s" % (url, quote(keywords), query_string)
+        query_parameters = ["keywords=%s"%quote(keywords),query_string]
+        
+        if 'recycledItems' in kwargs:
+            query_parameters.append('recycledItems=%s' % kwargs['recycledItems'])
+        if 'closedProjectsOnly' in kwargs:
+            query_parameters.append('closedProjectsOnly=%s' % kwargs['closedProjectsOnly'])
+
+        resource_url = "%s?%s" % (url,"&".join(query_parameters))
 ##
 ##        print(resource_url)
 ##


### PR DESCRIPTION
We could manage to have all parameters (including the keywords) managed as basic kwargs in _buildRequest but these 2 are valid only when using search.